### PR TITLE
Fix disasm issue

### DIFF
--- a/projects/4917/cpu/disassembler.py
+++ b/projects/4917/cpu/disassembler.py
@@ -34,7 +34,8 @@ def disassemble(state, highlight, cycle=0):
         elif type == InstructionType.IO:
             if index >= len(memory) - 1:
                 # End of memory, no operand: treat as data
-                print(f" {index:02d}: {IS:02d}")
+                print(f" {index:02d}: {IS:02d}     ???")
+                index += 1
             else:
                 operand = memory[index + 1]
                 print(
@@ -44,7 +45,8 @@ def disassemble(state, highlight, cycle=0):
         elif type == InstructionType.MEMORY:
             if index >= len(memory) - 1:
                 # End of memory, no operand: treat as data
-                print(f" {index:02d}: {IS:02d}")
+                print(f" {index:02d}: {IS:02d}     ???")
+                index += 1
             else:
                 operand = memory[index + 1]
                 match = REGISTER_PATTERN.match(mnemonic)

--- a/projects/4917/simulator.py
+++ b/projects/4917/simulator.py
@@ -51,6 +51,7 @@ def main():
     # for debugging purposes:
     # filename = r".\projects\4917\deck\02.prg"
     # visualizer = disassemble
+    # debug = True
 
     with open(filename) as file:
         try:


### PR DESCRIPTION
Caused by not handling missing second nibble at memory end of a two nibble instruction. Now displayed as unknown:

```console
❯ python .\simulator.py -v asm -d on .\deck\08.prg

 IP: 0, R0: 0, R1: 0, Cycle: 0

>00: 09 15  LD    R0,15
 02: 14 12  BZ    12
 04: 11 07  ST    R0,7
 06: 08 00  PRINT 0
 08: 05     DEC   R0
 09: 13 02  B     2
 11: 00     HLT  
 12: 00     HLT  
 13: 00     HLT  
 14: 00     HLT  
 15: 12     ???
hit enter to continue or 'q' enter to quit> 
```