### PR TITLE
Fix PRINT instruction

### DIFF
--- a/projects/4917/cpu/instruction_set.py
+++ b/projects/4917/cpu/instruction_set.py
@@ -84,7 +84,7 @@ def BEEP():
 
 
 def PRINT(R0, R1, IP, memory):
-    print("***", memory[memory[IP]], "***\n")
+    print("***", memory[IP], "***\n")
     return R0, R1, memory
 
 


### PR DESCRIPTION
I misinterpreted what you wanted PRINT to do. It's operand is a literal, not a memory location.